### PR TITLE
修正组件类型定义，去除一系列 JSX.IntrinsicElements 组件类型定义的 DefineComponent 泛型包裹

### DIFF
--- a/packages/uni-app-components/tsconfig.json
+++ b/packages/uni-app-components/tsconfig.json
@@ -3,8 +3,5 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "vueCompilerOptions": {
-    "plugins": ["@uni-helper/uni-types/volar-plugin"]
-  },
   "include": ["src/**/*.ts", "src/**/*.vue", "*.d.ts"]
 }

--- a/packages/uni-app-types/src/basic-components/progress.ts
+++ b/packages/uni-app-types/src/basic-components/progress.ts
@@ -154,7 +154,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      progress: _Progress;
+      progress: _ProgressProps;
     }
   }
 }
@@ -171,7 +171,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      progress: _Progress;
+      progress: _ProgressProps;
     }
   }
 }

--- a/packages/uni-app-types/src/basic-components/text.ts
+++ b/packages/uni-app-types/src/basic-components/text.ts
@@ -121,7 +121,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      text: _Text;
+      text: _TextProps;
     }
   }
 }
@@ -140,7 +140,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      text: _Text;
+      text: _TextProps;
     }
   }
 }

--- a/packages/uni-app-types/src/canvas/index.ts
+++ b/packages/uni-app-types/src/canvas/index.ts
@@ -153,7 +153,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      canvas: _Canvas;
+      canvas: _CanvasProps;
     }
   }
 }
@@ -169,7 +169,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      canvas: _Canvas;
+      canvas: _CanvasProps;
     }
   }
 }

--- a/packages/uni-app-types/src/form-components/button.ts
+++ b/packages/uni-app-types/src/form-components/button.ts
@@ -778,7 +778,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      button: _Button;
+      button: _ButtonProps;
     }
   }
 }
@@ -794,7 +794,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      button: _Button;
+      button: _ButtonProps;
     }
   }
 }

--- a/packages/uni-app-types/src/form-components/form.ts
+++ b/packages/uni-app-types/src/form-components/form.ts
@@ -131,7 +131,7 @@ declare global {
        *
        * 将组件内的用户输入的 switch、input、checkbox、slider、radio、picker 提交
        */
-      form: _Form;
+      form: _FormProps;
     }
   }
 }
@@ -150,7 +150,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      form: _Form;
+      form: _FormProps;
     }
   }
 }

--- a/packages/uni-app-types/src/form-components/input.ts
+++ b/packages/uni-app-types/src/form-components/input.ts
@@ -537,7 +537,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      input: _Input;
+      input: _InputProps;
     }
   }
 }
@@ -553,7 +553,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      input: _Input;
+      input: _InputProps;
     }
   }
 }

--- a/packages/uni-app-types/src/form-components/label.ts
+++ b/packages/uni-app-types/src/form-components/label.ts
@@ -83,7 +83,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      label: _Label;
+      label: _LabelProps;
     }
   }
 }
@@ -106,7 +106,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      label: _Label;
+      label: _LabelProps;
     }
   }
 }

--- a/packages/uni-app-types/src/form-components/switch.ts
+++ b/packages/uni-app-types/src/form-components/switch.ts
@@ -100,7 +100,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      switch: _Switch;
+      switch: _SwitchProps;
     }
   }
 }
@@ -116,7 +116,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      switch: _Switch;
+      switch: _SwitchProps;
     }
   }
 }

--- a/packages/uni-app-types/src/form-components/textarea.ts
+++ b/packages/uni-app-types/src/form-components/textarea.ts
@@ -355,7 +355,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      textarea: _Textarea;
+      textarea: _TextareaProps;
     }
   }
 }
@@ -371,7 +371,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      textarea: _Textarea;
+      textarea: _TextareaProps;
     }
   }
 }

--- a/packages/uni-app-types/src/map/index.ts
+++ b/packages/uni-app-types/src/map/index.ts
@@ -914,7 +914,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      map: _Map;
+      map: _MapProps;
     }
   }
 }
@@ -930,7 +930,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      map: _Map;
+      map: _MapProps;
     }
   }
 }

--- a/packages/uni-app-types/src/media-components/audio.ts
+++ b/packages/uni-app-types/src/media-components/audio.ts
@@ -174,7 +174,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      audio: _Audio;
+      audio: _AudioProps;
     }
   }
 }
@@ -190,7 +190,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      audio: _Audio;
+      audio: _AudioProps;
     }
   }
 }

--- a/packages/uni-app-types/src/media-components/image.ts
+++ b/packages/uni-app-types/src/media-components/image.ts
@@ -241,7 +241,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      image: _Image;
+      image: _ImageProps;
     }
   }
 }
@@ -257,7 +257,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      image: _Image;
+      image: _ImageProps;
     }
   }
 }

--- a/packages/uni-app-types/src/media-components/video.ts
+++ b/packages/uni-app-types/src/media-components/video.ts
@@ -668,7 +668,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      video: _Video;
+      video: _VideoProps;
     }
   }
 }
@@ -687,7 +687,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      video: _Video;
+      video: _VideoProps;
     }
   }
 }

--- a/packages/uni-app-types/src/view-containers/view.ts
+++ b/packages/uni-app-types/src/view-containers/view.ts
@@ -107,7 +107,7 @@ declare global {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      view: _View;
+      view: _ViewProps;
     }
   }
 }
@@ -128,7 +128,7 @@ declare module "vue/jsx-runtime" {
        * |
        * [使用说明](https://uni-typed.netlify.app/)
        */
-      view: _View;
+      view: _ViewProps;
     }
   }
 }

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -23,10 +23,6 @@
       "@uni-helper/uni-types"
     ]
   },
-  "vueCompilerOptions": {
-    // 调整 Volar（Vue 语言服务工具）解析行为，用于为 uni-app 组件提供 TypeScript 类型
-    "plugins": ["@uni-helper/uni-types/volar-plugin"]
-  },
   "include": [
     "src/**/*.ts",
     "src/**/*.d.ts",


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

修改点：
1. 修正组件类型定义，去除一系列 `JSX.IntrinsicElements` 组件类型定义的 `DefineComponent` 泛型包裹
2. 仓库内相关联的项目，移除 `tsconfig.json` 中的 `vueCompilerOptions` 配置

### Linked Issues 关联的 Issues

暂无

### Additional context 额外上下文

观察分析了 view、text、image 这些组件发现：

此类组件是浏览器的自带组件，与自定义组件不同，此类组件的类型定义是处于 `JSX.IntrinsicElements` 命名空间下的，被 vue 内置定义了一遍；

恰巧 uniapp 内置组件中存在此类重名的现象，故，使用需要在 `JSX.IntrinsicElements` 命名空间下定义该类组件的类型才可以实现类型定义的覆盖；

自定义组件，也就是上列提到的组件之外的组件，其类型定义是处于 `vue.GlobalComponents` 空间下的。

---

观察发现，两种组件的类型定义不可复用，主要区别在于， `JSX.IntrinsicElements` 命名空间下的组件类型定义直接就是组件的 props 定义即可，如果存在 `DefineComponent` 泛型包裹则导致编辑器提示报错，见 <https://github.com/uni-helper/uni-typed/issues/27> 。

---

关于 `vueCompilerOptions` 的配置说明：

观察发现，配置了 `vueCompilerOptions`，并且能够达到预期的提示效果的项目，是因为该配置强制将上述的 `JSX.IntrinsicElements` 组件转向 `vue.GlobalComponents` 空间下的类型定义，所以才达到了配置 `vueCompilerOptions` 能生效的表现，并不是当前 `JSX.IntrinsicElements` 组件的定义正确与否的判断依据。
