### PR TITLE
fix: uni-app-types's `_LivePusherProps.aspect` should be type `string`

### DIFF
--- a/packages/uni-app-types/src/media-components/live-pusher.ts
+++ b/packages/uni-app-types/src/media-components/live-pusher.ts
@@ -464,7 +464,7 @@ type _LivePusherProps = CommonProps &
      *
      * 默认为 3:2
      */
-    aspect: number;
+    aspect: string;
     /**
      * 是否静音
      *


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

The type of `_LivePusherProps.aspect` from `@uni-helper/uni-app-types` is `number` currently, while the document of uni-app says it's `string`, see [https://uniapp.dcloud.net.cn/component/live-pusher.html](https://uniapp.dcloud.net.cn/component/live-pusher.html)

### Linked Issues 关联的 Issues

null

### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->

null
